### PR TITLE
启用 R8 优化压缩 DEX 字节码来显著缩减 APK 尺寸

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -98,7 +98,7 @@ android {
             if (hasReleaseSigning) {
                 signingConfig = signingConfigs.getByName("release")
             }
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,36 +1,25 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
-
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
-# Keep native library methods
--keep class com.fuwaki.synap.SynapLib { *; }
--keep class com.fuwaki.synap.SynapCore { *; }
-
-# Keep JNI native methods
+# Keep JNI method names for any classes that still expose native methods.
 -keepclasseswithmembernames class * {
     native <methods>;
 }
 
-# Keep JNI related classes
--keep class com.fuwaki.synap.** { *; }
--keep class uniffi.synap_coreffi.** { *; }
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+-keepattributes SourceFile,LineNumberTable
+
+# JNA's native bridge (`libjnidispatch.so`) looks up many JNA classes, fields,
+# and methods by their original names. The stable practice is to keep the JNA
+# namespace intact rather than chasing individual members across versions.
+-keep class com.sun.jna.** { *; }
+-keep interface com.sun.jna.** { *; }
+
+# JNA contains desktop-only AWT helpers which are never used on Android.
+# Suppress warnings for those optional references when the package is kept.
+-dontwarn java.awt.**
+
+# Keep the generated UniFFI bindings package intact as the JNA-facing ABI layer.
+-keep class com.fuwaki.synap.bindings.uniffi.synap_coreffi.** { *; }
+-keep interface com.fuwaki.synap.bindings.uniffi.synap_coreffi.** { *; }
 
 # Keep Kotlin coroutines
 -keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}


### PR DESCRIPTION
# 描述
我在 `build.gradle.kts` 中启用了 `release` 的 `isMinifyEnabled` 选项，来启用 R8 构建优化，它采用多种技术来优化 DEX 字节码，包括 Tree-shaking 和代码混淆等，参见[文档](https://developer.android.google.cn/topic/performance/app-optimization/enable-app-optimization?hl=zh-cn)。

为了让优化有效，我修正了 `proguard-rules.pro`，确保 Rust 绑定相关的类和依赖库不被混淆。

我还在混淆规则中设置了保留行号信息，以方便定位 Release 构建中输出的 stacktrace 信息中的问题。

# 结果
我已在 debug 和 release 配置下对 app 启动、创建修改删除搜索笔记功能进行测试，工作正常。

**构建 release APK 大小显著缩小，从 20MiB 缩小到 9.3MiB。**